### PR TITLE
submodules for more cogs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rsmp"]
+    path = "cogs/rsmp"
+    url = "https://github.com/RoseSMP/rsmp-cogs"

--- a/bot.py
+++ b/bot.py
@@ -127,6 +127,12 @@ async def stop(interaction: nextcord.Interaction, extension):
 for filename in os.listdir('./cogs'):
     if filename.endswith('.py'):
         bot.load_extension(f'cogs.{filename[:-3]}')
+# Load Cogs from enabled Submodules
+if cfg["tiramisu"]["use_cog_submodules"]:
+    for submodule in cfg["cog_submodules"]["cog_submodules"]:
+        for filename in os.listdir(f'./cogs/{submodule}'):
+            if filename.endswith(".py"):
+                bot.load_extension(f"cogs.{submodule}.{filename[:-3]}")
 
 # Run the Bot
 bot.run(bot_token)

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,3 +11,8 @@ discord:
 messages:
   noperm: 'No permission'
   noperm_log: f'User {interactions.user} tried to run "{cmd}" but doesnt have permission!'
+
+cog_submodules:
+  use_cog_submodules: True
+  cog_submodules:
+    - "rsmp"

--- a/config/exampleconfig.yml
+++ b/config/exampleconfig.yml
@@ -10,3 +10,8 @@ discord:
 messages:
   noperm: 'No permission'
   noperm_log: f'User {interactions.user} tried to run "{cmd}" but doesnt have permission!'
+
+tiramisu:
+  use_cog_submodules: False
+  cog_submodules:
+    #- "rsmp"

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -3,7 +3,11 @@
 First, clone this repository. To do so, run the following command:
 
 ```sh
-git clone https://github.com/RoseSMP/rosebot-3
+git clone https://github.com/RoseSMP/rosebot-3.git
+```
+If you want to also clone our custom cogs specific to RoseSMP, run the following command instead:
+```sh
+git clone --recurse-submodules https://github.com/RoseSMP/rosebot-3.git
 ```
 
 ## Installing


### PR DESCRIPTION
# Just an idea, yet to be tested.
Essentially, when defined in the config, the `.py` files in `./cogs/{submodule}/` will be loaded if listed in the array in `./config/config.yml`. In this way, users (and us) can easily implement changes to cogs in another repo, without messing with the original rosebot-3/tiramisu repo and everything stays neat and tidy for prod.